### PR TITLE
Add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # pAPI SDK
 
+![main workflow](https://github.com/ostrovok-team/papi-sdk-python/workflows/Main/badge.svg)
+![pypi version](https://img.shields.io/pypi/v/papi-sdk.svg)
+![pypi downloads](https://img.shields.io/pypi/dm/papi-sdk.svg)
+![python versions](https://img.shields.io/pypi/pyversions/papi-sdk.svg)
+![license](https://img.shields.io/github/license/ostrovok-team/papi-sdk-python.svg)
+
 pAPI SDK is a python SDK for [ETG APIv3](https://docs.emergingtravel.com/).
 The abbreviation "pAPI" stands for "Partner API". 
 


### PR DESCRIPTION
I added a set of simple common badges: CI status, pypi version and download count, compatible python versions, license.

Download count may not work, because I think it is indexed only for "big" packages and there should be more than say 100 downloads.

Closes #3 